### PR TITLE
#152134757 Get started tour for admin or vendors

### DIFF
--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
@@ -41,7 +41,11 @@ Template.CoreNavigationBar.helpers({
       kind: "flat",
       label: "Tour",
       onClick() {
-        takeTour();
+        const currentLocation = location.href.split("/")[location.href.split("/").length - 1];
+        if (currentLocation === "") {
+          return takeTour();
+        }
+        return "";
       }
     };
   },

--- a/imports/plugins/included/tour/takeTour.js
+++ b/imports/plugins/included/tour/takeTour.js
@@ -7,7 +7,7 @@ const userTour = [
     intro: `<h2>Welcome to <strong>Reaction Commerce</strong></h2>
     <hr>
     <div class="tourcontainer">
-      This brief tour will guide you through some of the features on the platform.
+      This brief tour will guide you through some of the features of the platform.
     </div>`
   },
   {
@@ -55,22 +55,25 @@ const userTour = [
     intro: `<h2>Tour</h2>
     <hr>
     <div class="tourcontainer">
-      That's for joining me in the tour. Ever need to take a tour again, I am right here.
+      Thanks for joining me in the tour. Ever need to take a tour again, I am right here.
     </div>`
   }
 ];
+
 const vendorTour = [
   {
     intro: `<h2>Welcome to <strong>Reaction</strong> Commerce</h2>
     <hr>
     <div class="tourcontainer">
+      This brief tour will guide you through some of the features of the platform.
     </div>`
   },
   {
-    element: ".product-grid-list",    
+    element: ".product-grid-list",
     intro: `<h2>Products</h2>
     <hr>
     <div class="tourcontainer">
+      Your products are displayed in grids here.
     </div>`
   },
   {
@@ -78,27 +81,15 @@ const vendorTour = [
     intro: `<h2>Search</h2>
     <hr>
     <div class="tourcontainer">
+      Your customers can perform intuitive search here and discover products that interest them
     </div>`
   },
   {
     element: ".cart",
-    intro: `<h2>My Cart</h2>
+    intro: `<h2>Shopping Cart</h2>
     <hr>
     <div class="tourcontainer">
-    </div>`
-  },
-  {
-    element: ".languages",
-    intro: `<h2>Languages</h2>
-    <hr>
-    <div class="tourcontainer">
-    </div>`
-  },
-  {
-    element: ".more",
-    intro: `<h2>Static Pages Options</h2>
-    <hr>
-    <div class="tourcontainer">
+      This is the shopping cart which shows the amount of items your customers have selected for purchase.
     </div>`
   },
   {
@@ -106,6 +97,16 @@ const vendorTour = [
     intro: `<h2>Account Options</h2>
     <hr>
     <div class="tourcontainer">
+      Access account controls here by choosing from one of the listed options in the 
+      dropdown
+    </div>`
+  },
+  {
+    element: ".languages",
+    intro: `<h2>Languages</h2>
+    <hr>
+    <div class="tourcontainer">
+      Select your preferred language here.
     </div>`
   },
   {
@@ -113,6 +114,7 @@ const vendorTour = [
     intro: `<h2>Admin Controls</h2>
     <hr>
     <div class="tourcontainer">
+      Use this tab to access Admin/Vendor functionalities such as your dashboard and content
     </div>`
   },
   {
@@ -120,6 +122,7 @@ const vendorTour = [
     intro: `<h2>Tour</h2>
     <hr>
     <div>
+    Thanks for joining me in the tour. Ever need to take a tour again, I am right here.
     </div>`
   }
 ];
@@ -137,7 +140,8 @@ export function takeTour() {
     scrollToElement: true,
     showStepNumbers: false,
     tooltipPosition: "auto",
-    steps: tourSteps
+    steps: tourSteps,
+    disableInteraction: true
   });
   tour.start();
 }


### PR DESCRIPTION
#### What does this PR do?
Adds a get started tour for admin or vendors or shop owners

#### Description of Task to be completed?
- ensures an admin or vendor can take a tour of the Reaction Commerce application

#### How should this be manually tested?
- go to http://localhost:3000/ in your browser
- login as an admin or shop owner
- click on the tour button found at the main navigation header of the landing page

#### Any background context you want to provide?
- This functionality builds on the get started tour for buyers, with added information and personalization.
- It ensures that you can only take the tour when you are in areas that requires the tour such as the landing page.

#### What are the relevant pivotal tracker stories?
Story ID: #152134757
Story Type: feature
Story: Getting Started Tour for Vendors

#### Screenshots (if appropriate)
![localhost-3000- 2](https://user-images.githubusercontent.com/13672476/32270336-d77ee684-bef5-11e7-9730-941affa5357b.png)

#### Questions:
N/A