### PR TITLE
#151994139 Static Page Management

### DIFF
--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -1,3 +1,25 @@
+<template name="staticPagesNav">
+  <div class="dropdown" role="menu">
+    <div class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="1000">
+      <span id="logged-in-display-name"> Pages<b class="caret"></b></span>
+    </div>
+    <div class="dropdown-menu" role="menu">
+      <div class="user-accounts-dropdown">
+        <ul class="user-accounts-dropdown-apps">
+          {{#each staticPage in staticPages}}
+            <li class="dropdown-apps-icon">
+              <a href="/pages/{{staticPage.slug}}" id="dropdown-apps-{{staticPage.title}}" title="{{staticPage.title}}">
+                <i class="fa fa-file-text-o"></i>
+                {{staticPage.title}}
+              </a>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
 <template name="loginDropdown">
   <div class="dropdown" role="menu">
     {{#if currentUser}}

--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -1,7 +1,7 @@
 <template name="staticPagesNav">
   <div class="dropdown" role="menu">
     <div class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="1000">
-      <span id="logged-in-display-name"> Pages<b class="caret"></b></span>
+      <span id="logged-in-display-name"> Info<b class="caret"></b></span>
     </div>
     <div class="dropdown-menu" role="menu">
       <div class="user-accounts-dropdown">

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -1,5 +1,5 @@
 import { Reaction, Logger } from "/client/api";
-import { Tags } from "/lib/collections";
+import { Tags, StaticPages } from "/lib/collections";
 import { Session } from "meteor/session";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
@@ -80,5 +80,23 @@ Template.accountsDropdownApps.events({
   "click #dropdown-apps-onboarding": function (event) {
     event.preventDefault();
     Reaction.Router.go("/reaction/get-started/");
+  }
+});
+
+
+Template.staticPagesNav.onCreated(function () {
+  this.autorun(() => {
+    this.subscribe("viewPages");
+  });
+});
+
+Template.staticPagesNav.helpers({
+  staticPages() {
+    const instance = Template.instance();
+    if (instance.subscriptionsReady()) {
+      return StaticPages.find({
+        shopId: Reaction.getShopId()
+      });
+    }
   }
 });

--- a/client/modules/router/main.js
+++ b/client/modules/router/main.js
@@ -303,6 +303,16 @@ Router.isActiveClassName = (routeName) => {
   return routeDef === routeName ? "active" : "";
 };
 
+// Route for static pages
+Router.route("/pages/:slug", {
+  action(params) {
+    ReactionLayout({
+      template: "staticPageDisplay",
+      slug: params.slug
+    });
+  }
+});
+
 // Register Global Route Hooks
 Meteor.startup(() => {
   Router.Hooks.onEnter(checkRouterPermissions);

--- a/client/templates.js
+++ b/client/templates.js
@@ -1,1 +1,2 @@
 Template.rainierProducts.replaces("products");
+Template.rainierFooter.replaces("layoutFooter");

--- a/client/templates/products/footer.html
+++ b/client/templates/products/footer.html
@@ -22,10 +22,10 @@
         </div>
         <div class="col-md-3 col-sm-12">
           <h3 class="rainier-footer-header"><strong>Payment</strong></h3>
-          <img src="resources/payment/rc-visa.png" alt="payment-provider" class="payment-icon">
-          <img src="resources/payment/rc-mastercard.png" alt="payment-provider" class="payment-icon">
-          <img src="resources/payment/rc-verve.png" alt="payment-provider" class="payment-icon">
-          <img src="resources/payment/rc-quickteller.png" alt="payment-provider" class="payment-icon">
+          <img src="/resources/payment/rc-visa.png" alt="payment-provider" class="payment-icon">
+          <img src="/resources/payment/rc-mastercard.png" alt="payment-provider" class="payment-icon">
+          <img src="/resources/payment/rc-verve.png" alt="payment-provider" class="payment-icon">
+          <img src="/resources/payment/rc-quickteller.png" alt="payment-provider" class="payment-icon">
         </div>
       </div>
     </div>

--- a/client/templates/products/footer.html
+++ b/client/templates/products/footer.html
@@ -2,24 +2,23 @@
   <footer class="rainier-footer">
     <div class="container">
       <div class="row">
-        <div class="col-md-3 col-sm-6">
-          <h3 class="rainier-footer-header"><strong>Need Help?</strong></h3>
-          <p><a href="#">Contact Us</a></p>
-          <p><a href="#">How to shop on Reaction</a></p>
-          <p><a href="#">Shipping and Delivery</a></p>
-        </div>
-        <div class="col-md-3 col-sm-6">
-          <h3 class="rainier-footer-header"><strong>Make Money</strong></h3>
-          <p><a href="#">Sell products on Reaction</a></p>
-          <p><a href="#">Become a sales consultant</a></p>
-          <p><a href="#">Advertise on Reaction</a></p>
-        </div>
-        <div class="col-md-3 col-sm-6">
-          <h3 class="rainier-footer-header"><strong>Pages</strong></h3>
-          <p><a href="#">About Us</a></p>
-          <p><a href="#">FAQ</a></p>
-          <p><a href="#">We&apos;re hiring</a></p>
-          <p><a href="#">Terms&amp;Conditions</a></p>
+        <div class="col-md-9 col-sm-12">
+          {{#if staticPagesByCategory}}
+            {{#each category in staticPagesByCategory}}
+              <div class="col-md-4 col-sm-6">
+                <h3 class="rainier-footer-header">
+                  {{#if category.[0].category}}
+                    <strong>{{category.[0].category}}</strong>
+                    {{else}}
+                    <strong>Pages</strong>
+                  {{/if}}
+                </h3>
+                {{#each page in category }}
+                  <p><a href="/pages/{{page.slug}}">{{page.title}}</a></p>
+                {{/each}}
+              </div>
+            {{/each}}
+          {{/if}}
         </div>
         <div class="col-md-3 col-sm-12">
           <h3 class="rainier-footer-header"><strong>Payment</strong></h3>

--- a/client/templates/products/footer.js
+++ b/client/templates/products/footer.js
@@ -1,0 +1,25 @@
+import { Reaction } from "/client/api";
+import { Template } from "meteor/templating";
+import { StaticPages } from "/lib/collections";
+
+import "./footer.html";
+
+Template.rainierFooter.onCreated(function () {
+  Meteor.subscribe("staticPages");
+});
+
+Template.rainierFooter.helpers({
+  staticPages() {
+    return StaticPages.find({shopId: Reaction.shopId}).fetch();
+  },
+  staticPagesByCategory() {
+    const pages = StaticPages.find({shopId: Reaction.shopId}).fetch();
+    const categories = [];
+    pages.forEach((page) => {
+      if (!categories.includes(page.category)) {
+        categories.push(page.category);
+      }
+    });
+    return categories.map(category => pages.filter(page => page.category === category));
+  }
+});

--- a/client/templates/products/rainier-home.html
+++ b/client/templates/products/rainier-home.html
@@ -25,5 +25,4 @@
       <div class="spinner"></div>
     </div>
   {{/if}}
-  {{> rainierFooter}}
 </template>

--- a/client/templates/staticPages/staticPage.html
+++ b/client/templates/staticPages/staticPage.html
@@ -1,0 +1,12 @@
+<template name="staticPageDisplay">
+  <div class="container">
+    <div class="row">
+      {{#each pageDetail in staticPage slug}}
+      <div class="col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3 mtop-20">
+        <h2 class="center-text"><strong>{{pageDetail.title}}</strong></h2>
+        <p class="static-content">{{{pageDetail.content}}}</p>
+      </div>
+      {{/each}}
+    </div>
+  </div>
+</template>

--- a/client/templates/staticPages/staticPage.html
+++ b/client/templates/staticPages/staticPage.html
@@ -1,5 +1,5 @@
 <template name="staticPageDisplay">
-  <div class="container">
+  <div class="container static-page-wrapper">
     <div class="row">
       {{#each pageDetail in staticPage slug}}
       <div class="col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3 mtop-20">

--- a/client/templates/staticPages/staticPage.html
+++ b/client/templates/staticPages/staticPage.html
@@ -3,8 +3,8 @@
     <div class="row">
       {{#each pageDetail in staticPage slug}}
       <div class="col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3 mtop-20">
-        <h2 class="center-text"><strong>{{pageDetail.title}}</strong></h2>
-        <p class="static-content">{{{pageDetail.content}}}</p>
+        <h2 class="center-text pad-20 rainier-bottom-bordered"><strong>{{pageDetail.title}}</strong></h2>
+        <p class="static-content pad-10">{{{pageDetail.content}}}</p>
       </div>
       {{/each}}
     </div>

--- a/client/templates/staticPages/staticPage.js
+++ b/client/templates/staticPages/staticPage.js
@@ -1,5 +1,6 @@
 import { StaticPages } from "/lib/collections";
 import { Template } from "meteor/templating";
+import marked from "marked";
 
 Template.staticPageDisplay.onCreated(function () {
   this.autorun(() => {
@@ -13,8 +14,9 @@ Template.staticPageDisplay.helpers({
     if (instance.subscriptionsReady()) {
       const page = StaticPages.find({slug}).fetch();
       if (page.length > 0) {
-        const data = { title, content} = page;
-        return data;
+        const data = { title, content} = page[0];
+        data.content = marked(data.content);
+        return [data];
       }
     }
   }

--- a/client/templates/staticPages/staticPage.js
+++ b/client/templates/staticPages/staticPage.js
@@ -1,0 +1,21 @@
+import { StaticPages } from "/lib/collections";
+import { Template } from "meteor/templating";
+
+Template.staticPageDisplay.onCreated(function () {
+  this.autorun(() => {
+    this.subscribe("StaticPages");
+  });
+});
+
+Template.staticPageDisplay.helpers({
+  staticPage(slug) {
+    const instance = Template.instance();
+    if (instance.subscriptionsReady()) {
+      const page = StaticPages.find({slug}).fetch();
+      if (page.length > 0) {
+        const data = { title, content} = page;
+        return data;
+      }
+    }
+  }
+});

--- a/imports/plugins/core/layout/client/index.js
+++ b/imports/plugins/core/layout/client/index.js
@@ -7,6 +7,7 @@ import "./templates/layout/alerts/reactionAlerts.js";
 import "./templates/layout/createContentMenu/createContentMenu.html";
 import "./templates/layout/createContentMenu/createContentMenu.js";
 import "./templates/layout/footer/footer.html";
+import "./templates/layout/footer/footer.js";
 import "./templates/layout/header/brand.html";
 import "./templates/layout/header/button.html";
 import "./templates/layout/header/header.html";

--- a/imports/plugins/core/layout/client/templates/layout/footer/footer.js
+++ b/imports/plugins/core/layout/client/templates/layout/footer/footer.js
@@ -2,13 +2,14 @@ import { Reaction } from "/client/api";
 import { Template } from "meteor/templating";
 import { StaticPages } from "/lib/collections";
 
-import "./footer.html";
 
-Template.rainierFooter.onCreated(function () {
-  Meteor.subscribe("staticPages");
+Template.layoutFooter.onCreated(function () {
+  this.autorun(() => {
+    this.subscribe("staticPages");
+  });
 });
 
-Template.rainierFooter.helpers({
+Template.layoutFooter.helpers({
   staticPages() {
     return StaticPages.find({shopId: Reaction.shopId}).fetch();
   },

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -9,6 +9,7 @@
     <div class="tour tourBtn">{{> React TourButtonComponent}}</div>
     <div class="search search-test">{{> React IconButtonComponent}}</div>
     <div class="languages hidden-xs">{{> i18nChooser}}</div>
+    <div class="accounts">{{> accounts tpl="staticPagesNav"}}</div>
     <div class="accounts">{{> accounts tpl="loginDropdown"}}</div>
     <div class="cart">{{> cartIcon}}</div>
     <div class="cart-alert">{{> cartPanel}}</div>

--- a/imports/plugins/custom/rainier-blue/client/index.js
+++ b/imports/plugins/custom/rainier-blue/client/index.js
@@ -1,3 +1,3 @@
 // Entrypoint for client files. This includes your React components
 
-import './index.less';
+import "./index.less";

--- a/imports/plugins/custom/rainier-blue/client/styles/main.less
+++ b/imports/plugins/custom/rainier-blue/client/styles/main.less
@@ -96,6 +96,10 @@ span.fa-chevron-right {
   padding: 5px;
 }
 
+.pad-10 {
+  padding: 10px;
+}
+
 .static-controls {
   background-color: #fafafa;
 }

--- a/imports/plugins/custom/rainier-blue/client/styles/main.less
+++ b/imports/plugins/custom/rainier-blue/client/styles/main.less
@@ -74,3 +74,60 @@ span.fa-chevron-right {
   display: inline-flex;
   margin: 0 20px 20px 0;
 }
+
+.static-sidebar {
+  border-right: 2px solid rgba(16, 61, 190, 0.1);
+  height: 95vh;
+  width: 22%;
+  overflow-y: scroll;
+  position: fixed;
+  padding-bottom: 100px;
+}
+
+.cool-blue-border-right {
+  border-right: 2px solid rgba(16, 61, 190, 0.1);
+}
+
+.rainier-bottom-bordered {
+  border-bottom: 1px solid rgba(16, 61, 190, 0.1);
+}
+
+.pad-20 {
+  padding: 5px;
+}
+
+.static-controls {
+  background-color: #fafafa;
+}
+
+.static-controls button {
+  margin: 2px;
+}
+
+.stay-left {
+  float: left;
+}
+
+.stay-right {
+  float: right;
+}
+
+.padright-20 {
+  padding-right: 20px;
+}
+.mtop-20 {
+  margin-top: 20px;
+}
+
+#clear-fields {
+  margin-top: 20px;
+}
+
+.static-content {
+  font-size: 2rem;
+  font-weight: 200;
+}
+
+.center-text {
+  text-align: center !important;
+}

--- a/imports/plugins/custom/rainier-blue/client/styles/main.less
+++ b/imports/plugins/custom/rainier-blue/client/styles/main.less
@@ -54,6 +54,11 @@ span.fa-chevron-right {
 }
 
 /** footer **/
+.footer-default {
+  bottom: 0;
+  padding: 40px 0;
+}
+
 .rainier-footer {
   background: linear-gradient(0deg, #fafafa, rgba(16, 61, 190, 0.04));
   border-top: 2px solid rgba(16, 61, 190, 0.1);
@@ -134,4 +139,8 @@ span.fa-chevron-right {
 
 .center-text {
   text-align: center !important;
+}
+
+.static-page-wrapper {
+  min-height: 55vh;
 }

--- a/imports/plugins/custom/rainier-static-pages/client/index.js
+++ b/imports/plugins/custom/rainier-static-pages/client/index.js
@@ -1,0 +1,1 @@
+import "./templates";

--- a/imports/plugins/custom/rainier-static-pages/client/templates/index.js
+++ b/imports/plugins/custom/rainier-static-pages/client/templates/index.js
@@ -1,0 +1,2 @@
+import "./rainierCreateStaticPages.html";
+import "./rainierCreateStaticPages";

--- a/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.html
+++ b/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.html
@@ -1,0 +1,65 @@
+<template name="rainierCreateStaticPages">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-3 visible-md visible-lg">
+        <div class="static-sidebar">
+          {{> staticPagesList}}
+        </div>
+      </div>
+      <div class="col-md-9 padright-20">
+        <div class="col-md-12">
+          <h3 class="col-md-8" id="page-heading">Create New Page</h3>
+          <div class="col-md-4">
+            <input class="btn btn-primary stay-right" id="clear-fields" type="button" value="reset form">
+          </div>
+        </div>
+        <form class="col-sm-12 create-page-form" action="" method="post">
+          <input id="_id" type="text" name="_id" hidden="true">
+          <div class="form-group">
+            <label for="pageCategory">Page Category</label>
+            <input class="form-control" id="category" type="text" name="pageCategory" value="">
+          </div>
+          <div class="form-group">
+            <label for="title">Page Title</label>
+            <input class="form-control" id="title" type="text" name="pageTitle" value="">
+          </div>
+          <div class="form-group">
+            <label for="content">Page Content</label>
+            <textarea class="form-control" id="content" rows="8" name="content"></textarea>
+          </div>
+          <div class="form-group">
+            <input class="form-control btn btn-success" id="submit" type="submit" value="SUBMIT">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<template name="staticPagesList">
+  <div class="rainier-bottom-bordered">
+    <h3 class="center">Your pages</h3>
+  </div>
+  {{#if staticPages}}
+    {{#each staticPage in staticPages}}
+      <div class="col-md-12 pad-20 rainier-bottom-bordered">
+        <div class="col-md-8">
+          <h5>
+            {{staticPage.title}}
+          </h5>
+        </div>
+        <div class="col-md-4 static-controls">
+          <button class="btn-primary edit-page left" data-id="{{staticPage._id}}">
+            <i class="fa fa-pencil edit-page" data-id="{{staticPage._id}}"></i>
+          </button>
+          <button class="btn-danger delete-page right" data-id="{{staticPage._id}}">
+            <i class="fa fa-trash edit-page" data-id="{{staticPage._id}}"></i>
+          </button>
+        </div>
+      </div>
+    {{/each}}
+    {{else}}
+      <h5>No pages yet</h5>
+  {{/if}}
+</template>

--- a/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.js
+++ b/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.js
@@ -41,7 +41,7 @@ Template.rainierCreateStaticPages.events({
     const createdAt = new Date();
     if (_id) {
       return Meteor.call(
-        "editPage", _id, title, category, slug, content, shopId, (error) => {
+        "editPage", _id, title, slug, category, content, shopId, (error) => {
           if (error) {
             Alerts.toast(error.message, "error", {
               autoHide: 1000

--- a/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.js
+++ b/imports/plugins/custom/rainier-static-pages/client/templates/rainierCreateStaticPages.js
@@ -1,0 +1,132 @@
+import SimpleMDE from "simplemde";
+import { Reaction } from "/client/api";
+import { Template } from "meteor/templating";
+import { StaticPages } from "/lib/collections";
+
+import "/node_modules/simplemde/dist/simplemde.min.css";
+import "./rainierCreateStaticPages.html";
+
+/**
+ * creates slug from input
+ * @param  {String} text text input
+ * @return {String}      slug
+ */
+const sluggify = text => text.toLowerCase().trim().replace(/\s/g, "-");
+
+let editor;
+Template.rainierCreateStaticPages.onRendered(() => {
+  editor = new SimpleMDE({
+    element: document.getElementById("content"),
+    placeholder: "Enter page content...",
+    spellChecker: true,
+    hideIcons: ["image"],
+    autoDownloadFontAwesome: false,
+    renderingConfig: {
+      singleLineBreaks: false,
+      codeSyntaxHighlighting: true
+    }
+  });
+});
+
+Template.rainierCreateStaticPages.events({
+  "submit .create-page-form": (event) => {
+    event.preventDefault();
+    const _id = $("#_id").val();
+    const title = $("#title").val();
+    const slug = sluggify(title);
+    const content = $("#content").val();
+    const category = $("#category").val();
+    const shopId = Reaction.shopId;
+    const pageOwner = Meteor.user()._id;
+    const createdAt = new Date();
+    if (_id) {
+      return Meteor.call(
+        "editPage", _id, title, category, slug, content, shopId, (error) => {
+          if (error) {
+            Alerts.toast(error.message, "error", {
+              autoHide: 1000
+            });
+          } else {
+            $("#title").val("");
+            $("#_id").val("");
+            $("#category").val("");
+            editor.value("");
+            Alerts.toast("Page updated sucessfully!", "success", {
+              autoHide: 1000
+            });
+          }
+          document.getElementById("page-heading").textContent = "Create New Page";
+        });
+    }
+    return Meteor.call(
+      "createPage", title, slug, category, content, shopId, pageOwner, createdAt,
+      (error) => {
+        if (error) {
+          Alerts.toast(error.message, "error", {
+            autoHide: 1000
+          });
+        } else {
+          $("#title").val("");
+          $("#_id").val("");
+          $("#category").val("");
+          editor.value("");
+          Alerts.toast("Page created sucessfully!", "success", {
+            autoHide: 1000
+          });
+        }
+      });
+  },
+  "click #clear-fields": (event) => {
+    event.preventDefault();
+    $("#title").val("");
+    $("#_id").val("");
+    $("#category").val("");
+    editor.value("");
+  }
+});
+
+
+Template.staticPagesList.onCreated(function () {
+  Meteor.subscribe("staticPages");
+});
+
+Template.staticPagesList.helpers({
+  staticPages() {
+    return StaticPages.find({shopId: Reaction.shopId}).fetch();
+  }
+});
+
+Template.staticPagesList.events({
+  "click .edit-page"(event) {
+    const element = event.target;
+    const _id = $(element).attr("data-id");
+    const page = StaticPages.find({ _id }).fetch();
+
+    document.getElementById("_id").value = page[0]._id || "";
+    const title = document.getElementById("title");
+    title.value = page[0].title || "";
+    const category = document.getElementById("category");
+    category.value = page[0].category || "";
+    editor.value(page[0].content);
+    document.getElementById("page-heading").textContent = "Edit Page";
+  },
+
+  "click .delete-page"(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    Alerts.alert({
+      title: "Remove Static Page?",
+      type: "warning",
+      showCancelButton: true,
+      cancelButtonText: "No",
+      confirmButtonText: "Yes"
+    }, (confirmed) => {
+      if (confirmed) {
+        const element = event.target;
+        const id = $(element).attr("data-id");
+        Meteor.call("deletePage", id);
+      }
+      return false;
+    });
+  }
+});

--- a/imports/plugins/custom/rainier-static-pages/register.js
+++ b/imports/plugins/custom/rainier-static-pages/register.js
@@ -1,0 +1,42 @@
+import { Reaction } from "/server/api";
+
+Reaction.registerPackage({
+  label: "Static Pages",
+  name: "reaction-static-pages",
+  icon: "fa fa-list",
+  autoEnable: true,
+  settings: {
+    name: "Static Pages"
+  },
+  registry: [
+    {
+      provides: "dashboard",
+      route: "/dashboard/static",
+      name: "static-pages",
+      label: "Static Pages",
+      description: "Manage static pages",
+      icon: "fa fa-list",
+      priority: 1,
+      container: "core",
+      workflow: "coreProductWorkflow",
+      template: "rainierCreateStaticPages"
+    }
+  ],
+  layout: [{
+    layout: "coreLayout",
+    workflow: "coreProductWorkflow",
+    collection: "StaticPages",
+    theme: "default",
+    enabled: true,
+    structure: {
+      template: "rainierCreateStaticPages",
+      layoutHeader: "layoutHeader",
+      layoutFooter: "layoutFooter",
+      notFound: "notFound",
+      dashboardHeader: "dashboardHeader",
+      dashboardControls: "dashboardControls",
+      dashboardHeaderControls: "dashboardControls",
+      adminControlsFooter: "adminControlsFooter"
+    }
+  }]
+});

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -165,3 +165,11 @@ Themes.attachSchema(Schemas.Themes);
 export const Translations = new Mongo.Collection("Translations");
 
 Translations.attachSchema(Schemas.Translation);
+
+
+/**
+* Static Pages Collection
+*/
+export const StaticPages = new Mongo.Collection("StaticPages");
+
+StaticPages.attachSchema(Schemas.StaticPages);

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -21,3 +21,4 @@ export * from "./templates";
 export * from "./themes";
 export * from "./translations";
 export * from "./workflow";
+export * from "./staticPages";

--- a/lib/collections/schemas/staticPages.js
+++ b/lib/collections/schemas/staticPages.js
@@ -1,0 +1,63 @@
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import { Random } from "meteor/random";
+
+/**
+ * Static page schema
+ */
+export const StaticPages = new SimpleSchema({
+  _id: {
+    type: String,
+    optional: true,
+    defaultValue: Random.id()
+  },
+  title: {
+    type: String,
+    label: "title", // should be unique
+    index: true,
+    unique: true
+  },
+  slug: {
+    type: String,
+    label: "slug", // has to be unique
+    index: true,
+    unique: true
+  },
+  category: {
+    type: String,
+    optional: true
+  },
+  content: {
+    type: String,
+    label: "content"
+  },
+  shopId: {
+    type: String,
+    label: "shopId"
+  },
+  pageOwner: {
+    type: String,
+    label: "pageOwner"
+  },
+  createdAt: {
+    type: Date,
+    autoValue() {
+      if (this.isInsert) {
+        return new Date();
+      } else if (this.isUpsert) {
+        return {$setOnInsert: new Date()};
+      }
+      this.unset();  // Prevent user from supplying their own value
+      denyUpdate: true;
+    }
+  },
+  updatedAt: {
+    type: Date,
+    autoValue() {
+      if (this.isUpdate) {
+        return new Date();
+      }
+    },
+    denyInsert: true,
+    optional: true
+  }
+});

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-taco-table": "^0.5.0",
     "react-tether": "^0.5.2",
     "react-textarea-autosize": "^4.0.5",
+    "simplemde": "^1.11.2",
     "sortablejs": "^1.4.2",
     "stripe": "^4.11.0",
     "sweetalert2": "^5.3.8",

--- a/server/methods/core/staticPage.js
+++ b/server/methods/core/staticPage.js
@@ -1,0 +1,80 @@
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+import * as Collections from "/lib/collections";
+import * as Schemas from "../../../lib/collections/schemas";
+
+Meteor.methods({
+  /**
+   * Creates a Static Page
+   * @param {String} title      page title
+   * @param {String} slug       page slug
+   * @param {String} category   page category
+   * @param {String} content    content of the page
+   * @param {String} shopId     ShopId of the page
+   * @param {String} pageOwner  vendor id
+   * @param {String} createdAt  datetime string at object creation
+   * @return {void}             there is no return value
+   */
+  createPage: function (title, slug, category, content, shopId, pageOwner, createdAt) {
+    check(title, String);
+    check(slug, String);
+    check(category, String);
+    check(content, String);
+    check(shopId, String);
+    check(pageOwner, String);
+    check(createdAt, Date);
+
+    const page = {
+      title,
+      slug,
+      category,
+      content,
+      shopId,
+      pageOwner,
+      createdAt
+    };
+    check(page, Schemas.StaticPages);
+    Collections.StaticPages.insert(page);
+  },
+
+  /**
+   * Edits a Static Page
+   * @param {String} _id      ID of the page to be updated
+   * @param {String} title    new page title
+   * @param {String} slug     new page slug
+   * @param {String} category page category
+   * @param {String} content  new page content
+   * @param {String} shopId   shopId
+   * @return {void}           updates a shop document
+   */
+  "editPage"(_id, title, slug, category, content, shopId) {
+    check(_id, String);
+    check(title, String);
+    check(slug, String);
+    check(category, String);
+    check(content, String);
+    check(shopId, String);
+
+    const page = {
+      title,
+      slug,
+      category,
+      content,
+      shopId
+    };
+    Collections.StaticPages.update(_id, {
+      $set:
+        page
+    });
+  },
+
+  /**
+   * Deletes a Static Page
+   * @param {String} _id - The id of the page to be deleted
+   * @return {void}        deletes a page. Returns nothing
+   */
+  "deletePage"(_id) {
+    check(_id, String);
+    Collections.StaticPages.remove(_id);
+  }
+});

--- a/server/publications/collections/staticPage.js
+++ b/server/publications/collections/staticPage.js
@@ -7,3 +7,7 @@ Meteor.publish("staticPages", function () {
   }
   return StaticPages.find({});
 });
+
+Meteor.publish("viewPages", function () {
+  return StaticPages.find({});
+});

--- a/server/publications/collections/staticPage.js
+++ b/server/publications/collections/staticPage.js
@@ -1,0 +1,9 @@
+import { Meteor } from "meteor/meteor";
+import { StaticPages } from "/lib/collections";
+
+Meteor.publish("staticPages", function () {
+  if (!this.userId) {
+    return this.ready();
+  }
+  return StaticPages.find({});
+});


### PR DESCRIPTION
#### What does this PR do?
adds support for static pages

#### Description of Task to be completed?
Create and edit static pages, such as Contact, About, or Support.

#### How should this be manually tested?
- Navigate to application in browser
- Log in as admin
- On the dashboard, click on static pages
- Fill the form as appropriate
- On the homepage, a link to the created page should be in the footer
- Click on it to see the new page


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#151994139

#### Screenshots (if appropriate)

**admin view**

![localhost_3000_reaction_dashboard_static](https://user-images.githubusercontent.com/16195512/32412844-581ab41a-c204-11e7-83f7-367d4384ea97.png)

**Edit mode**

![localhost_3000_reaction_dashboard_static 1](https://user-images.githubusercontent.com/16195512/32412846-5bea7b16-c204-11e7-9660-9a56635aa230.png)

**Links on Home page**
![localhost_3000_pages_shipping-and-delivery](https://user-images.githubusercontent.com/16195512/32412847-5f72c05e-c204-11e7-9d43-ce120fcf87c8.png)

**Sample static Page**
![localhost_3000_pages_shipping-and-delivery 1](https://user-images.githubusercontent.com/16195512/32412848-63609f74-c204-11e7-8bdb-2b0028e146cb.png)


#### Questions: